### PR TITLE
ci: added jdk version required by IOM 4.2 (#79642)

### DIFF
--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -74,7 +74,8 @@ jobs:
     DBACCOUNT_IMAGE_TAG: 1.5.0
     
     # JDK version, depending on IOM version (space before \ is required).
-    IOM2JDK:      "[4.1]=11 \
+    IOM2JDK:      "[4.2]=17 \
+                   [4.1]=11 \
                    [4.0]=11"
 
     UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -286,7 +286,8 @@ jobs:
       
       # Start minikube
       docker version --format {{.Server.Os}}-{{.Server.Version}}
-      minikube start --vm-driver=docker
+      # hardcoded cpu/memory requirements for now
+      minikube start --vm-driver=docker --cpus=max --memory=8000m
     displayName: "Start minikube"
     timeoutInMinutes: 5
     #enabled: false
@@ -336,7 +337,7 @@ jobs:
   
   - script: |
       set -e
-
+            
       # Create values file.
       cat > values.yaml <<EOF
       replicaCount: $REPLICA_COUNT
@@ -369,6 +370,14 @@ jobs:
           enabled: false
         service:
           type: LoadBalancer
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 3000Mi
+          requests:
+            cpu: 1000m
+            memory: 1000Mi
+
       mailhog:
         enabled: true
         probes:


### PR DESCRIPTION
do not merge yet. Please wait for the migration of IOM Blueprint Project to IOM 4.2. This version of Blueprint Project is the first project, that uses IOM 4.2 and the Partner DevOps Pipeline.