### PR TITLE
allow usage of smaller VMs

### DIFF
--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -336,7 +336,11 @@ jobs:
   
   - script: |
       set -e
-
+      
+      ps -o pid,user,%mem,command ax | sort -b -k3 -r
+      free -m
+      kubectl top pod --all-namespaces
+      
       # Create values file.
       cat > values.yaml <<EOF
       replicaCount: $REPLICA_COUNT
@@ -416,6 +420,9 @@ jobs:
       # Wait for import of test-data + 1 minute.
       # If import of test-data fails, the pod will be restarted.
       sleep $(expr $IMPORT_TESTDATA_TIMEOUT + 60)
+      ps -o pid,user,%mem,command ax | sort -b -k3 -r
+      free -m
+      kubectl top pod --all-namespaces
     timeoutInMinutes: 30
     workingDirectory: $(Pipeline.Workspace)
     displayName: "Install IOM in minikube"

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -286,6 +286,8 @@ jobs:
       
       # Start minikube
       docker version --format {{.Server.Os}}-{{.Server.Version}}
+      minikube config set memory 8000
+      minikube config set cpus 4
       minikube start --vm-driver=docker
       minikube addons enable metrics-server
     displayName: "Start minikube"

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -287,9 +287,7 @@ jobs:
       # Start minikube
       docker version --format {{.Server.Os}}-{{.Server.Version}}
       # hardcoded cpu/memory requirements for now
-      minikube config set memory 8000
-      minikube config set cpus max
-      minikube start --vm-driver=docker
+      minikube start --vm-driver=docker --cpus=max --memory=8000m
     displayName: "Start minikube"
     timeoutInMinutes: 5
     #enabled: false

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -287,6 +287,7 @@ jobs:
       # Start minikube
       docker version --format {{.Server.Os}}-{{.Server.Version}}
       minikube start --vm-driver=docker
+      minikube addons enable metrics-server
     displayName: "Start minikube"
     timeoutInMinutes: 5
     #enabled: false
@@ -339,7 +340,7 @@ jobs:
       
       ps -o pid,user,%mem,command ax | sort -b -k3 -r
       free -m
-      kubectl top pod --all-namespaces
+      kubectl top pod --all-namespaces || true
       
       # Create values file.
       cat > values.yaml <<EOF
@@ -422,7 +423,7 @@ jobs:
       sleep $(expr $IMPORT_TESTDATA_TIMEOUT + 60)
       ps -o pid,user,%mem,command ax | sort -b -k3 -r
       free -m
-      kubectl top pod --all-namespaces
+      kubectl top pod --all-namespaces || true
     timeoutInMinutes: 30
     workingDirectory: $(Pipeline.Workspace)
     displayName: "Install IOM in minikube"

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -286,10 +286,10 @@ jobs:
       
       # Start minikube
       docker version --format {{.Server.Os}}-{{.Server.Version}}
+      # hardcoded cpu/memory requirements for now
       minikube config set memory 8000
-      minikube config set cpus 4
+      minikube config set cpus max
       minikube start --vm-driver=docker
-      minikube addons enable metrics-server
     displayName: "Start minikube"
     timeoutInMinutes: 5
     #enabled: false
@@ -339,11 +339,7 @@ jobs:
   
   - script: |
       set -e
-      
-      ps -o pid,user,%mem,command ax | sort -b -k3 -r
-      free -m
-      kubectl top pod --all-namespaces || true
-      
+            
       # Create values file.
       cat > values.yaml <<EOF
       replicaCount: $REPLICA_COUNT
@@ -376,6 +372,14 @@ jobs:
           enabled: false
         service:
           type: LoadBalancer
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 3000Mi
+          requests:
+            cpu: 1000m
+            memory: 1000Mi
+
       mailhog:
         enabled: true
         probes:
@@ -423,9 +427,6 @@ jobs:
       # Wait for import of test-data + 1 minute.
       # If import of test-data fails, the pod will be restarted.
       sleep $(expr $IMPORT_TESTDATA_TIMEOUT + 60)
-      ps -o pid,user,%mem,command ax | sort -b -k3 -r
-      free -m
-      kubectl top pod --all-namespaces || true
     timeoutInMinutes: 30
     workingDirectory: $(Pipeline.Workspace)
     displayName: "Install IOM in minikube"


### PR DESCRIPTION
- setting limits on global CPU/memory usage for minikube
- added resource requests/limits for postgresql 

--> now possible to use Ds3v2 instead of Ds4v2