### PR TITLE
[Backport stable/v1] PR #25: ci: add -XX:MaxRAM to workaround JVM cgroups v2 issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,57 @@
+# see https://developercommunity.visualstudio.com/t/variables-in-yaml-pipeline-are-not-allowing-to-def/812728
+parameters:
+- name: blueprintInstances
+  type: object
+  default:
+    - repository:    iom-blueprint-project-develop
+      artifactsFeed: iom-maven-artifacts
+      id:            _develop
+    - repository:    iom-blueprint-project-1-3-1
+      artifactsFeed: order-iom-releases
+      id:            _1_3_1
+
+# Library iom-build-configuration is provided by Intershops DevOps Environment. It provides
+# the following variables:
+#  - BUILD_AGENT_POOL:                  name of the build agent pool
+#  - REPO_SERVICE_CONNECTION:           service connection to the customer ACR
+#  - REPO_PATH:                         host name and path of the customer ACR
+#  - INTERSHOP_REPO_SERVICE_CONNECTION: service connection to the Intershop container registry
+#  - INTERSHOP_REPO_PATH:               host name and path of the Intershop container registry
+variables:
+- group: iom-build-configuration
+
+resources:
+  repositories:
+    - repository: iom-blueprint-project-develop
+      type:       github
+      endpoint:   github-intershop
+      name:       intershop/iom-blueprint-project
+      ref:        develop
+    - repository: iom-blueprint-project-1-3-1
+      type:       github
+      endpoint:   github-intershop
+      name:       intershop/iom-blueprint-project
+      ref:        refs/tags/1.3.1
+
+trigger:
+  branches:
+    include:
+      - '*'
+
+# see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops#extend-from-a-template
+# see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops#use-other-repositories
+stages:
+- stage: CI
+  jobs:
+    - ${{ each entry in parameters.blueprintInstances }}:
+      - template: ci-job-template.yml
+        parameters:
+          repository:                         ${{ entry.repository }}
+          agentPool:                          $(BUILD_AGENT_POOL)
+          artifactsFeed:                      ${{ entry.artifactsFeed }}
+          dockerRepoIOMServiceConnection:     $(INTERSHOP_REPO_SERVICE_CONNECTION)
+          dockerRepoIOM:                      $(INTERSHOP_REPO_PATH)
+          acrServiceConnection:               $(REPO_SERVICE_CONNECTION)
+          acr:                                $(REPO_PATH)
+          projectEnvName:                     dev
+          id:                                 ${{ entry.id }}

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -4,12 +4,42 @@
 ################################################################################
 parameters:
 
+  # Has to be set, if ci-job-template.yml is used in a loop, for two reasons:
+  # - to make each job-name unique,
+  # - to extend names of files, which are published in extensions.
+  # For this reason id must consitst of characters, numbers and _ only.
+- name: id
+  type: string
+  default: ''
+  
+  # Enables an easy integration with custom jobs. The parameter will be passed
+  # as is to the 'dependsOn' property of the job.
+- name: dependsOn
+  type: string
+  default: ''
+
+  # Enables an easy integration with custom jobs. The parameter will be passed
+  # as is to the 'condition' property of the job.
+- name: condition
+  type: string
+  default: ''
+
   # Every partner has it's own agent-pool, therefore the name of the pool cannot
   # be hardcoded in the pipeline template.
 - name: agentPool
   type: string
   default: ''
 
+  # Has to be set, if the project is placed in a subdirectory.
+- name: projectDir
+  type: string
+  default: ''
+
+  # Has to be set, if the project is located in a remote repository.
+- name: repository
+  type: string
+  default: self
+  
   # Service connection to the Docker repository, containing the IOM product
   # images.
 - name: dockerRepoIOMServiceConnection
@@ -49,8 +79,10 @@ parameters:
   default: '^refs/heads/develop$\|^refs/heads/master$\|^refs/heads/main$\|^refs/heads/release/\|^refs/heads/hotfix/'
 
 jobs:
-- job: CI
+- job: CI${{ parameters.id }}
   pool: '${{ parameters.agentPool }}'
+  dependsOn: ${{ parameters.dependsOn }}
+  condition: ${{ parameters.condition }}
   continueOnError: false
   timeoutInMinutes: 300
   workspace:
@@ -73,11 +105,6 @@ jobs:
     DBACCOUNT_IMAGE_NAME: iom-dbaccount
     DBACCOUNT_IMAGE_TAG: 1.5.0
     
-    # JDK version, depending on IOM version (space before \ is required).
-    IOM2JDK:      "[4.2]=17 \
-                   [4.1]=11 \
-                   [4.0]=11"
-
     UBUNTU_MIRROR: http://azure.archive.ubuntu.com/ubuntu/
     
     #---------------------------------------------------------------------------
@@ -154,31 +181,39 @@ jobs:
         echo "##[error] Parameter artifactsFeed must not be empty!"
         exit 1
       fi
-      
-      cat > "$PIPELINE_WORKSPACE/config.md" <<EOF
+      if [ ! -z "${{ parameters.id }}" ]; then
+        if echo "${{ parameters.id }}" | grep -q '[^a-zA-Z0-9_]'; then
+          echo "##[error] Parameter id has to consist of characters, numbers and _ only!"
+          exit 1
+        fi
+      fi
+
+      cat > "$PIPELINE_WORKSPACE/config${{ parameters.id }}.md" <<EOF
       # pipeline configuration
 
-          HELM_VERSION: $HELM_VERSION
-          IOM_HELM_VERSION: $IOM_HELM_VERSION
-          IOM_HELM_URL: $IOM_HELM_URL
-          IOM_HELM_RELEASE: $IOM_HELM_RELEASE
-          IOM_KUBERNETES_NAMESPACE: $IOM_KUBERNETES_NAMESPACE
-          REPLICA_COUNT: $REPLICA_COUNT
-          IMPORT_TESTDATA_TIMEOUT: $IMPORT_TESTDATA_TIMEOUT
+          HELM_VERSION:                   $HELM_VERSION
+          IOM_HELM_VERSION:               $IOM_HELM_VERSION
+          IOM_HELM_URL:                   $IOM_HELM_URL
+          IOM_HELM_RELEASE:               $IOM_HELM_RELEASE
+          IOM_KUBERNETES_NAMESPACE:       $IOM_KUBERNETES_NAMESPACE
+          REPLICA_COUNT:                  $REPLICA_COUNT
+          IMPORT_TESTDATA_TIMEOUT:        $IMPORT_TESTDATA_TIMEOUT
           
       # parameters
-      
+
+          id:                             ${{ parameters.id }}
+          projectDir:                     ${{ parameters.projectDir }}
           dockerRepoIOMServiceConnection: ${{ parameters.dockerRepoIOMServiceConnection }}
-          dockerRepoIOM: ${{ parameters.dockerRepoIOM }}
-          acrServiceConnection: ${{ parameters.acrServiceConnection }}
-          acr: ${{ parameters.acr }}
-          artifactsFeed: ${{ parameters.artifactsFeed }}
+          dockerRepoIOM:                  ${{ parameters.dockerRepoIOM }}
+          acrServiceConnection:           ${{ parameters.acrServiceConnection }}
+          acr:                            ${{ parameters.acr }}
+          artifactsFeed:                  ${{ parameters.artifactsFeed }}
       EOF
     timeoutInMinutes: 1
     displayName: "Check parameters"
     #enabled: false
 
-  - checkout: self
+  - checkout: ${{ parameters.repository }}
     path: $(PROJECT_PATH)
     clean: true
     timeoutInMinutes: 5
@@ -209,25 +244,25 @@ jobs:
       fi
 
       # Determine JDK version
-      declare -A IOM2JDK=( $(IOM2JDK) )
-
-      JDK_MAJOR_VERSION="${IOM2JDK[$IOM_MINOR_VERSION]}"
+      # TODO: xml_grep is not able to understand the expression /plugin[artifactId="maven-compiler-plugin"],
+      # which would be required to select the jdk version really the right way.
+      JDK_MAJOR_VERSION=$(xml_grep --text_only //plugins/plugin/configuration/release pom.xml)
       echo "##vso[task.setvariable variable=JDK_MAJOR_VERSION;]$JDK_MAJOR_VERSION"
 
-      cat >> "$PIPELINE_WORKSPACE/config.md" <<EOF
+      cat >> "$PIPELINE_WORKSPACE/config${{ parameters.id }}.md" <<EOF
 
       # project information
     
-          IOM_VERSION: $IOM_VERSION
-          IOM_MINOR_VERSION: $IOM_MINOR_VERSION
-          PROJECT_VERSION: $PROJECT_VERSION
+          IOM_VERSION:                    $IOM_VERSION
+          IOM_MINOR_VERSION:              $IOM_MINOR_VERSION
+          PROJECT_VERSION:                $PROJECT_VERSION
 
       # build environment
         
-          JDK_MAJOR_VERSION: $JDK_MAJOR_VERSION
+          JDK_MAJOR_VERSION:              $JDK_MAJOR_VERSION
       EOF
     timeoutInMinutes: 1
-    workingDirectory: $(Pipeline.Workspace)/$(PROJECT_PATH)
+    workingDirectory: $(Pipeline.Workspace)/$(PROJECT_PATH)/${{ parameters.projectDir }}
     displayName: "Get project properties"
     #enabled: false
 
@@ -302,14 +337,14 @@ jobs:
         -Dimage.docker.opts='--docker-opts="--no-cache" --get-image-name="'$PIPELINE_WORKSPACE/project-image-name.txt'" --get-image-tag="'$PIPELINE_WORKSPACE/project-image-tag.txt'"'
     timeoutInMinutes: 30
     displayName: "Create project image"
-    workingDirectory: "$(Pipeline.Workspace)/$(PROJECT_PATH)"
+    workingDirectory: "$(Pipeline.Workspace)/$(PROJECT_PATH)/${{ parameters.projectDir }}"
     #enabled: false
 
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'JUnit' # Options: JUnit, NUnit, VSTest, xUnit, cTest
       testResultsFiles: '**/TEST-*.xml'
-      searchFolder: '$(Pipeline.Workspace)/$(PROJECT_PATH)'
+      searchFolder: '$(Pipeline.Workspace)/$(PROJECT_PATH)/${{ parameters.projectDir }}'
       testRunTitle: junit-tests
       mergeTestResults: true 
       failTaskOnFailedTests: true
@@ -403,9 +438,9 @@ jobs:
       EOF
 
       # Convert values file into markdown format.
-      echo '# Helm values' > "$PIPELINE_WORKSPACE/values.md"
-      cat values.yaml | sed 's/\(.*\)/    \1/g' >> "$PIPELINE_WORKSPACE/values.md"
-      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/values.md"
+      echo '# Helm values' > "$PIPELINE_WORKSPACE/values${{ parameters.id }}.md"
+      cat values.yaml | sed 's/\(.*\)/    \1/g' >> "$PIPELINE_WORKSPACE/values${{ parameters.id }}.md"
+      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/values${{ parameters.id }}.md"
 
       # Start tunnel in background.
       # See https://minikube.sigs.k8s.io/docs/handbook/accessing/#loadbalancer-access
@@ -451,12 +486,12 @@ jobs:
         exit 1
       fi
 
-      cat >> "$PIPELINE_WORKSPACE/config.md" << EOF
+      cat >> "$PIPELINE_WORKSPACE/config${{ parameters.id }}.md" << EOF
 
       # kubernetes environment
 
-          INGRESS_IP:  $INGRESS_IP
-          POSTGRES_IP: $POSTGRES_IP
+          INGRESS_IP:                     $INGRESS_IP
+          POSTGRES_IP:                    $POSTGRES_IP
       EOF
     timeoutInMinutes: 5
     displayName: Get external IPs
@@ -486,7 +521,7 @@ jobs:
       EOF
 
       # Provide testframework config files in markdown format
-      cat > "$PIPELINE_WORKSPACE/testconfig.md" <<EOF
+      cat > "$PIPELINE_WORKSPACE/testconfig${{ parameters.id }}.md" <<EOF
       # testframework-config.yaml
 
       $(cat testframework-config.yaml | sed 's/\(.*\)/    \1/g')
@@ -495,10 +530,10 @@ jobs:
       
       $(cat testframework-config.user.yaml | sed 's/\(.*\)/    \1/g')
       EOF
-      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/testconfig.md"
+      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/testconfig${{ parameters.id }}.md"
 
       mvn verify | tee "$PIPELINE_WORKSPACE/$LOG_DIR/surefire-output.txt"
-    workingDirectory: $(Pipeline.Workspace)/$(PROJECT_PATH)
+    workingDirectory: $(Pipeline.Workspace)/$(PROJECT_PATH)/${{ parameters.projectDir }}
     timeoutInMinutes: 60
     displayName: Excute tests
     #enabled: false
@@ -507,7 +542,7 @@ jobs:
     inputs:
       testResultsFormat: 'JUnit' # Options: JUnit, NUnit, VSTest, xUnit, cTest
       testResultsFiles: '**/failsafe-reports/TEST-*.xml'
-      searchFolder: '$(Pipeline.Workspace)/$(PROJECT_PATH)'
+      searchFolder: '$(Pipeline.Workspace)/$(PROJECT_PATH)/${{ parameters.projectDir }}'
       testRunTitle: integration-tests
       mergeTestResults: true 
       failTaskOnFailedTests: true
@@ -542,7 +577,7 @@ jobs:
     #enabled: false
 
   - publish: "$(Pipeline.Workspace)/$(LOG_DIR)"
-    artifact: iom-logs
+    artifact: iom-logs${{ parameters.id }}
     # Don't stop on error to get as much information as possible.   
     continueOnError: true
     timeoutInMinutes: 2
@@ -553,13 +588,13 @@ jobs:
   - script: |
       set -e
 
-      cat > "$PIPELINE_WORKSPACE/kubernetes.md" <<EOF
+      cat > "$PIPELINE_WORKSPACE/kubernetes${{ parameters.id }}.md" <<EOF
       # Kubernetes status of namespace $IOM_KUBERNETES_NAMESPACE
       Helm release is **${IOM_HELM_RELEASE}**.
       
       EOF
-      kubectl get all -n $IOM_KUBERNETES_NAMESPACE | sed 's/\(.*\)/    \1/g' >> "$PIPELINE_WORKSPACE/kubernetes.md"
-      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/kubernetes.md"
+      kubectl get all -n $IOM_KUBERNETES_NAMESPACE | sed 's/\(.*\)/    \1/g' >> "$PIPELINE_WORKSPACE/kubernetes${{ parameters.id }}.md"
+      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/kubernetes${{ parameters.id }}.md"
 
     # Don't stop on error to get as much information as possible.
     continueOnError: true
@@ -608,15 +643,15 @@ jobs:
       else
         echo '##vso[task.setvariable variable=IS_RELEASE_BUILD;]true'
       fi
-      cat >> "$PIPELINE_WORKSPACE/config.md" <<EOF
+      cat >> "$PIPELINE_WORKSPACE/config${{ parameters.id }}.md" <<EOF
 
       # release information
     
-          IS_PRIVATE_BRANCH: $IS_PRIVATE_BRANCH
-          IS_RELEASE_BUILD: $IS_RELEASE_BUILD
+          IS_PRIVATE_BRANCH:              $IS_PRIVATE_BRANCH
+          IS_RELEASE_BUILD:               $IS_RELEASE_BUILD
       EOF
     timeoutInMinutes: 1
-    workingDirectory: $(Pipeline.Workspace)/$(PROJECT_PATH)
+    workingDirectory: $(Pipeline.Workspace)/$(PROJECT_PATH)/${{ parameters.projectDir }}
     displayName: "Get info for publication of images"
     #enabled false
 
@@ -637,11 +672,11 @@ jobs:
       docker tag "$(cat $PIPELINE_WORKSPACE/project-image-name.txt):$(cat $PIPELINE_WORKSPACE/project-image-tag.txt)" $PROVIDED_IMAGE
       docker push $PROVIDED_IMAGE
 
-      cat > $PIPELINE_WORKSPACE/docker-image.md <<EOF
+      cat > $PIPELINE_WORKSPACE/docker-image${{ parameters.id }}.md <<EOF
       # Provided Docker image
           $PROVIDED_IMAGE
       EOF
-      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/docker-image.md"
+      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/docker-image${{ parameters.id }}.md"
 
     timeoutInMinutes: 5
     condition: and(succeeded(), eq(variables.IS_PRIVATE_BRANCH,false))
@@ -650,7 +685,7 @@ jobs:
 
   - script: |
       set -e
-      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/config.md"
+      echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/config${{ parameters.id }}.md"
     timeoutInMinutes: 1
     condition: always()
     continueOnError: true

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -428,6 +428,7 @@ jobs:
       # Create values file.
       cat > values.yaml <<EOF
       replicaCount: $REPLICA_COUNT
+      kubectlImageRepository: "bitnamilegacy/kubectl:1.32.1"
       image:
         repository: $(cat $PIPELINE_WORKSPACE/project-image-name.txt)
         tag: $(cat $PIPELINE_WORKSPACE/project-image-tag.txt)

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -114,7 +114,7 @@ jobs:
     
     # IOM Helm Charts.
     # TODO: use latest version
-    IOM_HELM_VERSION: 3.0.0
+    IOM_HELM_VERSION: 3.1.1
     IOM_HELM_URL: https://intershop.github.io/helm-charts
     
     DBACCOUNT_IMAGE_NAME: iom-dbaccount

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -554,6 +554,42 @@ jobs:
     #enabled: false
 
   - script: |
+      # Don't stop on error - capture diagnostics even if some commands fail
+      set +e
+      
+      echo "=== Kubernetes Cluster Status ==="
+      kubectl get all -n $IOM_KUBERNETES_NAMESPACE
+      
+      echo -e "\n=== Pod Status Details ==="
+      kubectl get pods -n $IOM_KUBERNETES_NAMESPACE -o wide
+      
+      echo -e "\n=== Pod Descriptions ==="
+      kubectl describe pods -n $IOM_KUBERNETES_NAMESPACE
+      
+      echo -e "\n=== Events in namespace ==="
+      kubectl get events -n $IOM_KUBERNETES_NAMESPACE --sort-by='.lastTimestamp'
+      
+      echo -e "\n=== Container Logs ==="
+      # Get all pods in the namespace
+      for POD in $(kubectl get pods -n $IOM_KUBERNETES_NAMESPACE -o jsonpath='{.items[*].metadata.name}'); do
+        echo -e "\n--- Logs for pod: $POD ---"
+        kubectl logs $POD -n $IOM_KUBERNETES_NAMESPACE --all-containers=true --prefix=true --tail=100 || echo "Failed to get logs for $POD"
+      done
+      
+      echo -e "\n=== Postgres Status ==="
+      kubectl logs -n $IOM_KUBERNETES_NAMESPACE -l app.kubernetes.io/name=postgres --tail=50 || echo "No postgres logs available"
+      
+      echo -e "\n=== NGINX Ingress Status ==="
+      kubectl get all -n nginx
+      kubectl logs -n nginx -l app.kubernetes.io/name=ingress-nginx --tail=50 || echo "No nginx logs available"
+    continueOnError: true
+    timeoutInMinutes: 5
+    condition: always()
+    workingDirectory: $(Pipeline.Workspace)
+    displayName: "Capture installation diagnostics"
+    #enabled: false
+
+  - script: |
       set -e
 
       # get IP of ingress

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -385,7 +385,7 @@ jobs:
       free -h
       
       # hardcoded cpu/memory requirements for now
-      minikube start --vm-driver=docker --cpus=max --memory=12000m
+      minikube start --vm-driver=docker --cpus=max --memory=8000m
     displayName: "Start minikube"
     timeoutInMinutes: 5
     #enabled: false
@@ -446,7 +446,7 @@ jobs:
       # Create values file.
       cat > values.yaml <<EOF
       replicaCount: $REPLICA_COUNT
-      kubectlImageRepository: "bitnamilegacy/kubectl:1.32.1"
+      kubectlImageRepository: bitnami/kubectl:latest
       image:
         repository: $(cat $PIPELINE_WORKSPACE/project-image-name.txt)
         tag: $(cat $PIPELINE_WORKSPACE/project-image-tag.txt)
@@ -476,12 +476,12 @@ jobs:
       resources:
         limits:
           cpu: 1000m
-          memory: 3500Mi
+          memory: 2500Mi
         requests:
           cpu: 1000m
-          memory: 3500Mi
+          memory: 2500Mi
       jboss:
-        javaOpts: "-XX:+UseContainerSupport -XX:MinRAMPercentage=60 -XX:MaxRAMPercentage=60"
+        javaOpts: "-XX:+UseContainerSupport -XX:MaxRAM=2500m -XX:MaxRAMPercentage=60"
       postgres:
         enabled: true
         persistence:
@@ -491,14 +491,21 @@ jobs:
         resources:
           limits:
             cpu: 2000m
-            memory: 3000Mi
+            memory: 2000Mi
           requests:
             cpu: 1000m
-            memory: 3000Mi
+            memory: 800Mi
       mailpit:
         enabled: true
         ingress:
           enabled: false
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 48Mi
       EOF
 
       # Convert values file into markdown format.
@@ -528,58 +535,22 @@ jobs:
         --set controller.scope.enabled=false
 
       kubectl create namespace $IOM_KUBERNETES_NAMESPACE
-      
+
       # Install IOM Helm charts
       helm repo add intershop $IOM_HELM_URL
       helm repo update
-      
+
       # Install IOM project.
       helm install $IOM_HELM_RELEASE intershop/iom --version $IOM_HELM_VERSION -f values.yaml --namespace $IOM_KUBERNETES_NAMESPACE --timeout 20m0s --wait
 
       # Wait for import of test-data + 1 minute.
       # If import of test-data fails, the pod will be restarted.
-      sleep $(expr $IMPORT_TESTDATA_TIMEOUT + 60)
-      # Show available memory
-      free -h
+      DURATION_SECONDS=$(expr $IMPORT_TESTDATA_TIMEOUT + 60)
+      sleep $DURATION_SECONDS
+
     timeoutInMinutes: 30
     workingDirectory: $(Pipeline.Workspace)
     displayName: "Install IOM in minikube"
-    #enabled: false
-
-  - script: |
-      # Don't stop on error - capture diagnostics even if some commands fail
-      set +e
-      
-      echo "=== Kubernetes Cluster Status ==="
-      kubectl get all -n $IOM_KUBERNETES_NAMESPACE
-      
-      echo -e "\n=== Pod Status Details ==="
-      kubectl get pods -n $IOM_KUBERNETES_NAMESPACE -o wide
-      
-      echo -e "\n=== Pod Descriptions ==="
-      kubectl describe pods -n $IOM_KUBERNETES_NAMESPACE
-      
-      echo -e "\n=== Events in namespace ==="
-      kubectl get events -n $IOM_KUBERNETES_NAMESPACE --sort-by='.lastTimestamp'
-      
-      echo -e "\n=== Container Logs ==="
-      # Get all pods in the namespace
-      for POD in $(kubectl get pods -n $IOM_KUBERNETES_NAMESPACE -o jsonpath='{.items[*].metadata.name}'); do
-        echo -e "\n--- Logs for pod: $POD ---"
-        kubectl logs $POD -n $IOM_KUBERNETES_NAMESPACE --all-containers=true --prefix=true --tail=100 || echo "Failed to get logs for $POD"
-      done
-      
-      echo -e "\n=== Postgres Status ==="
-      kubectl logs -n $IOM_KUBERNETES_NAMESPACE -l app.kubernetes.io/name=postgres --tail=50 || echo "No postgres logs available"
-      
-      echo -e "\n=== NGINX Ingress Status ==="
-      kubectl get all -n nginx
-      kubectl logs -n nginx -l app.kubernetes.io/name=ingress-nginx --tail=50 || echo "No nginx logs available"
-    continueOnError: true
-    timeoutInMinutes: 5
-    condition: always()
-    workingDirectory: $(Pipeline.Workspace)
-    displayName: "Capture installation diagnostics"
     #enabled: false
 
   - script: |
@@ -684,6 +655,8 @@ jobs:
       set +e
       
       kubectl get all -n $IOM_KUBERNETES_NAMESPACE > get-all.txt
+      kubectl get events -n $IOM_KUBERNETES_NAMESPACE --sort-by='.lastTimestamp' >> get-all.txt
+
       kubectl logs $IOM_HELM_RELEASE-iom-0 -n $IOM_KUBERNETES_NAMESPACE -c dbaccount > dbaccount-logs.txt
       I=0
       while [ "$I" -lt "$REPLICA_COUNT" ]; do
@@ -719,7 +692,8 @@ jobs:
       Helm release is **${IOM_HELM_RELEASE}**.
       
       EOF
-      kubectl get all -n $IOM_KUBERNETES_NAMESPACE | sed 's/\(.*\)/    \1/g' >> "$PIPELINE_WORKSPACE/kubernetes${{ parameters.id }}.md"
+      kubectl get all -n $IOM_KUBERNETES_NAMESPACE | sed 's/\(.*\)/    \1/g' >> "$PIPELINE_WORKSPACE/kubernetes${{ parameters.id }}.md"      
+      kubectl get events -n $IOM_KUBERNETES_NAMESPACE --sort-by='.lastTimestamp' | sed 's/\(.*\)/    \1/g' >> "$PIPELINE_WORKSPACE/kubernetes${{ parameters.id }}.md"
       echo "##vso[task.uploadsummary]$PIPELINE_WORKSPACE/kubernetes${{ parameters.id }}.md"
 
     # Don't stop on error to get as much information as possible.

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -123,10 +123,9 @@ jobs:
 
     # Version of Helm.
     #HELM_VERSION: 3.8.2
-    HELM_VERSION: 3.14.0
+    HELM_VERSION: 3.20.0
     
     # IOM Helm Charts.
-    # TODO: use latest version
     IOM_HELM_VERSION: 3.1.1
     IOM_HELM_URL: https://intershop.github.io/helm-charts
     


### PR DESCRIPTION
## Summary
Backport of #25 to `stable/v1`.

This ports the CI template changes originally merged to `main`:
- add JVM container memory setting for IOM (`-XX:MaxRAM=2500m` with `-XX:MaxRAMPercentage=60`)
- adjust pod memory/resource settings
- keep installation diagnostics capture step
- include events in Kubernetes status output
- use `kubectlImageRepository: bitnami/kubectl:latest`
- update Helm/IOM chart versions used by CI

## Source
Original PR: #25  
Merged into `main` from `build/ubuntu24-unstable`.

Cherry-picked commits:
- 9b51e3df4b0c269cbb2c773a1862307a09f757ff
- ab600074d5c7a9b317fc52d33a8019b3d41d99a5
- 58599bf4236b4057e4cdf40ada285bcc73826764

## Why
`stable/v1` needs the same CI stability fix for JVM cgroups v2/container memory behavior and aligned diagnostics/resource settings.

## Validation
- [x] Pipeline passes on `stable/v1`
- [x] No unintended changes beyond backport scope